### PR TITLE
add ttftovircon32

### DIFF
--- a/Tools/Readme.md
+++ b/Tools/Readme.md
@@ -1,0 +1,3 @@
+# CommunityContent: Vircon32 Tools
+
+This folder will contain tools related to Vircon32 console and it's software or development process.

--- a/Tools/Readme.md
+++ b/Tools/Readme.md
@@ -1,3 +1,3 @@
 # CommunityContent: Vircon32 Tools
 
-This folder will contain tools related to Vircon32 console and it's software or development process.
+This folder will contain tools and utilities related to Vircon32, its software or its development process.

--- a/Tools/ttftovircon32/.github/workflows/build_vcpkg.yml
+++ b/Tools/ttftovircon32/.github/workflows/build_vcpkg.yml
@@ -1,0 +1,77 @@
+name: Build with VCPKG
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually target the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-latest, env: Windows x86_64, triplet: x64-windows-static, binary: Release/ttftovircon.exe }
+          - { os: macos-13, env: Mac Os x64, triplet: x64-osx, binary: ttftovircon }
+          - { os: macos-latest, env: Mac Os arm64, triplet: arm64-osx, binary: ttftovircon }
+          - { os: ubuntu-20.04, env: Ubuntu x86_64, triplet: x64-linux, binary: ttftovircon }
+    runs-on: ${{ matrix.os }} 
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4      
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+      - name: install vcpkg
+        run : |
+          git clone --depth 1  https://github.com/microsoft/vcpkg "$HOME/vcpkg"          
+      - name: bootstrap vcpkg
+        if: runner.os == 'Windows'
+        run: |
+          cd "$HOME/vcpkg"
+          "bootstrap-vcpkg.bat"
+      - name: bootstrap vcpkg
+        if: runner.os != 'Windows'
+        run: |
+          cd "$HOME/vcpkg"
+          "./bootstrap-vcpkg.sh"
+      - name: configure triplet
+        run: |
+          cp "$HOME/vcpkg/triplets/${{ matrix.triplet }}.cmake" "$HOME/vcpkg/triplets/community/${{ matrix.triplet }}-release-only.cmake"
+          echo "set(VCPKG_BUILD_TYPE release)" >> "$HOME/vcpkg/triplets/community/${{ matrix.triplet }}-release-only.cmake"          
+      - name: Configure   
+        run: |
+          mkdir build
+          cd build
+          cmake "-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}-release-only" "-DCMAKE_TOOLCHAIN_FILE=$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake" ..      
+      - name: Build
+        run: |
+          cd build
+          cmake --build . --config Release
+      - name: Make Executable
+        if: runner.os != 'Windows'
+        run: |
+          chmod +x  build/${{ matrix.binary }}
+      - name: Copy Binary And Assets
+        run: |
+          mkdir ./Release
+          mkdir ./Release/ttftovircon
+          cp build/${{ matrix.binary }}  ./Release/ttftovircon/
+          cp ./README.md ./Release/ttftovircon/
+          cp ./LICENSE ./Release/ttftovircon/
+      - name: Tar Gzip everything
+        if: runner.os != 'Windows'
+        run : |
+          cd Release
+          tar -czvf "../ttftovircon ${{ matrix.env }}.tar.gz" ttftovircon
+      - name: Store build
+        uses: actions/upload-artifact@v4
+        if: runner.os != 'Windows'
+        with:
+          name: ttftovircon ${{ matrix.env }}
+          path: ./ttftovircon ${{ matrix.env }}.tar.gz
+      - name: Store build
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: ttftovircon ${{ matrix.env }}
+          path: ./Release/

--- a/Tools/ttftovircon32/CMakeLists.txt
+++ b/Tools/ttftovircon32/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE AND DEFINED ENV{CMAKE_TOOLCHAIN_FILE})
+   set(CMAKE_TOOLCHAIN_FILE $ENV{CMAKE_TOOLCHAIN_FILE})
+endif()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+endif()
+
+project(ttftovircon)
+
+find_package(SDL2 CONFIG REQUIRED)
+find_package(SDL2_image CONFIG REQUIRED)
+find_package(SDL2_ttf CONFIG REQUIRED)
+
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
+file(GLOB SRC CONFIGURE_DEPENDS
+        "${PROJECT_SOURCE_DIR}/src/*.cpp"
+        "${PROJECT_SOURCE_DIR}/src/*.h"
+        )
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBS OFF)
+if (! ${MACOSX})
+set(CMAKE_EXE_LINKER_FLAGS "-static")
+endif()
+
+add_executable(ttftovircon)
+target_sources(${PROJECT_NAME} PRIVATE ${SRC} )
+if (! ${MACOSX})
+target_link_libraries(${PROJECT_NAME} PRIVATE -static-libgcc -static-libstdc++)
+endif()
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2_image::SDL2_image-static SDL2_ttf::SDL2_ttf-static SDL2::SDL2main SDL2::SDL2-static)

--- a/Tools/ttftovircon32/LICENSE
+++ b/Tools/ttftovircon32/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Willems Davy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Tools/ttftovircon32/Makefile
+++ b/Tools/ttftovircon32/Makefile
@@ -1,0 +1,55 @@
+DEBUG=0
+SRC_DIR = src
+OBJ_DIR = obj
+EXE=ttftovircon
+
+SRC=$(wildcard $(SRC_DIR)/*.cpp)
+OBJS=$(SRC:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
+
+
+CPP = g++
+SDL2CONFIG ?= sdl2-config
+DEFINES ?= 
+DESTDIR ?=
+PREFIX ?= /usr
+OPT_LEVEL ?= -O2
+CPPFLAGS ?= -Wall -Wextra  `$(SDL2CONFIG) --cflags`
+LDFLAGS ?=
+
+#it was only way i could get it to link against static libs under msys2 / mingw
+ifeq ($(OS),Windows_NT)
+LDLIBS ?= -static -static-libgcc -static-libstdc++  `$(SDL2CONFIG) --static-libs` `pkg-config -libs -static SDL2_image SDL2_ttf` "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libSDL2_image.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libSDL2_image.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libSDL2_ttf.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libjpeg.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libpng16.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libharfbuzz.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libfreetype.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libjxl.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libavif.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libbz2.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libgraphite2.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libbrotlidec.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libbrotlicommon.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libaom.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libdav1d.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libhwy.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libwinpthread.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/librav1e.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libtiff.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libsharpyuv.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libwebp.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libstdc++.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libdeflate.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libjpeg.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libjbig.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/liblzma.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libyuv.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libwebpdemux.a" "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libzstd.a"  "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libLerc.a" 
+ifeq ($(MSYSTEM_PREFIX),/mingw64)
+LDLIBS += "$(PKG_CONFIG_SYSTEM_LIBRARY_PATH)/libSvtAv1Enc.a"
+endif
+else
+LDLIBS ?= `$(SDL2CONFIG) --libs` `pkgconf -libs -static SDL2_image SDL2_ttf`
+endif
+DEFINESADD = 
+FINALDEFINES = $(DEFINES) $(DEFINESADD)
+
+ifeq ($(OS),Windows_NT)
+LDLIBS += -mconsole
+endif
+
+ifeq ($(DEBUG), 1)
+CXXFLAGS += -g
+LDFLAGS += -g
+OPT_LEVEL =
+endif
+
+.PHONY: all clean
+
+all: $(EXE)
+
+$(EXE): $(OBJS)
+	$(CXX) $(OPT_LEVEL) $(LDFLAGS) $(TARGET_ARCH) $(FINALDEFINES) $^ $(LDLIBS) -o $@ 
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp | $(OBJ_DIR)  
+	$(CXX) $(OPT_LEVEL) $(CPPFLAGS) $(CXXFLAGS) $(FINALDEFINES) -c $< -o $@
+
+$(OBJ_DIR): 
+	mkdir -p $@
+
+clean:
+	$(RM) -rv *~ $(OBJ_DIR) $(EXE)

--- a/Tools/ttftovircon32/README.md
+++ b/Tools/ttftovircon32/README.md
@@ -1,0 +1,20 @@
+# ttftovircon32
+A Small program that can convert TTF fonts to images and code used by the Vircon32 [Textfonts library](https://github.com/vircon32/ConsoleSoftware/tree/main/Libraries/TextFonts)
+
+# dependencies
+* SDL2
+* SDL2_image
+* SDL2_ttf
+
+# usage
+compile using provided make file or use one of the files from [joyrider3774's repo](https://github.com/joyrider3774/ttftovircon32/releases/latest) section then use
+
+`ttftovircon [path/to/font.tff] [fontpointsize]`
+
+it will have generated a header file and the image you can use in the current working directory
+
+# credits
+created by [joyrider3774 aka Willems Davy](https://github.com/joyrider3774/)
+
+# license 
+MIT

--- a/Tools/ttftovircon32/src/main.cpp
+++ b/Tools/ttftovircon32/src/main.cpp
@@ -1,0 +1,313 @@
+#include <SDL.h>
+#include <SDL_ttf.h>
+#include <SDL_image.h>
+#include <cstring>
+#include <cstdlib>
+
+int MaxCharWidth = 0;
+int MaxCharHeight = 0;
+int CharWidths[8][16];
+void findMaxFontSizes(TTF_Font* font)
+{
+	char test[2];
+	test[1] = 0;
+	MaxCharHeight = TTF_FontHeight(font);
+	for (int y = 0; y < 8; y++)
+		for(int x = 0; x < 16; x++)
+		{
+			switch(y*16 +x)
+			{
+				case 1:
+					test[0] = 'M';
+					break;
+				case 3:
+					test[0] = 'W';
+					break;
+				case 5:
+					test[0] = 'I';
+					break;
+				default:
+					test[0] = y*16 +x;
+					break;
+			}
+			
+			TTF_SizeText(font, test, &CharWidths[y][x], NULL);
+			if(CharWidths[y][x] > MaxCharWidth)
+				MaxCharWidth = CharWidths[y][x]; 
+		}
+}
+
+char *gnu_basename(char *path)
+{
+	char *base = strrchr(path, '\\');
+    if (base)
+		return base+1;
+	else
+	{
+		char *base = strrchr(path, '/');
+    	return base ? base+1 : path;
+	}
+}
+
+void sanitize(char *fontName)
+{
+	char bad[8] = "-$ +*,.";
+	for (size_t i = 0; i < strlen(bad); i++)
+	{
+		char* tmp = strchr(fontName, bad[i]);
+		while(tmp)
+		{
+			*tmp = '_';
+			tmp = strchr(fontName, bad[i]);
+		}
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc != 3)
+	{
+		printf("use %s <path/to/font.ttf> <fontsize>\n", gnu_basename(argv[0]));
+		return 1;
+	}
+	if (SDL_Init(SDL_INIT_VIDEO) == 0)
+	{
+		 if( IMG_Init(IMG_INIT_PNG) == IMG_INIT_PNG)
+		 {
+			if( TTF_Init() == 0)
+			{
+				Uint32 rmask, gmask, bmask, amask;
+				#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+					rmask = 0xff000000;
+					gmask = 0x00ff0000;
+					bmask = 0x0000ff00;
+					amask = 0x000000ff;
+				#else
+					rmask = 0x000000ff;
+					gmask = 0x0000ff00;
+					bmask = 0x00ff0000;
+					amask = 0xff000000;
+				#endif
+				SDL_Surface *RendererSurface = SDL_CreateRGBSurface(0,2048,2048, 32, rmask, gmask, bmask, amask);
+				SDL_Renderer* Renderer = SDL_CreateSoftwareRenderer(RendererSurface);
+				if (Renderer)
+				{
+					SDL_RendererInfo rendererInfo;
+					SDL_GetRendererInfo(Renderer, &rendererInfo);
+					SDL_Log("Using Renderer:%s\n", rendererInfo.name);
+
+					int FontSize = atoi(argv[2]);
+					
+					TTF_Font* Font = TTF_OpenFont(argv[1], FontSize);
+					if(Font)
+					{
+						findMaxFontSizes(Font);		
+
+						SDL_Surface* TextSurface = SDL_CreateRGBSurface(0, MaxCharWidth * 16, MaxCharHeight * 8, 32, rmask, gmask, bmask, amask);
+						SDL_Renderer* TextRenderer = SDL_CreateSoftwareRenderer(TextSurface);
+						SDL_SetRenderDrawColor(TextRenderer, 0, 0, 0, 0);
+						SDL_RenderClear(TextRenderer);
+				
+						char FontName[1000];
+						char* base = gnu_basename(argv[1]);
+						strcpy(FontName, base);
+						char* ext = strrchr(FontName,'.');
+						if(ext)
+							*ext = 0;
+						strcat(FontName, "_");
+						strcat(FontName, argv[2]);
+						
+						sanitize(FontName);
+
+						char Code[20000];
+						char Nr[20];
+						char Char[2];
+						Char[1] = 0;
+						strcpy(Code, "#ifndef ");
+						strcat(Code, FontName);
+						strcat(Code, "_H\n");
+						strcat(Code, "#define ");
+						strcat(Code, FontName);
+						strcat(Code, "_H\n\n");
+
+						strcat(Code, "#include \"video.h\"\n");
+						strcat(Code, "#include \"libs/TextFonts/textfont.h\"\n\n");
+						strcat(Code, "#define ");
+						strcat(Code, FontName);
+						strcat(Code, "_texture_id 0\n");
+						strcat(Code, "#define ");
+						strcat(Code, FontName);
+						strcat(Code, "_region_id 0\n\n");
+						strcat(Code, "textfont Font");
+						strcat(Code, FontName);
+						strcat(Code, ";\n\n");
+						strcat(Code, "void setupFont");
+						strcat(Code, FontName);
+						strcat(Code, "()\n{\n");
+						strcat(Code, "select_texture(");
+						strcat(Code, FontName);
+						strcat(Code, "_texture_id);\n");
+    					//strcat(Code, "define_region_matrix(0,  0,0,  ");
+						//sprintf(Nr,"%d",MaxCharWidth-1);
+						//strcat(Code, Nr);
+						//strcat(Code, ",");
+						//sprintf(Nr,"%d",MaxCharHeight-1);
+						//strcat(Code, Nr);
+						//strcat(Code, ",  0,");
+						//strcat(Code, Nr);
+						//strcat(Code, ",  16,8,  0);\n");
+
+						for (int y = 0; y < 8; y++)
+							for(int x = 0; x < 16; x++)
+							{								
+								switch(y*16 +x)
+								{
+									case 1:
+										Char[0] = 'M';
+										break;
+									case 3:
+										Char[0] = 'W';
+										break;
+									case 5:
+										Char[0] = 'I';	
+										break;
+									default:
+										Char[0] = y*16 +x;
+										break;
+								}
+							    // then we redefine some characters to have different widths
+							    // (note that, for this font, upper and lowercase letters are the same)
+    							strcat(Code, "select_region(");
+								strcat(Code, FontName);
+								strcat(Code, "_region_id + ");
+								sprintf(Nr,"%d", y*16 + x);
+								strcat(Code, Nr);
+								strcat(Code, ");");
+								strcat(Code, " //");
+								if((y*16 +x >= 32) && (y*16 +x < 127) && (y*16 +x != 92))
+								{
+									strcat(Code, Char);
+								}
+								strcat(Code, " ");
+								sprintf(Nr,"%d",CharWidths[y][x]);
+								strcat(Code, Nr);
+								strcat(Code, "\n");
+    							strcat(Code, "define_region(");
+								sprintf(Nr,"%d",x * MaxCharWidth);
+								strcat(Code,  Nr);
+								strcat(Code, ",");
+								sprintf(Nr,"%d",y * MaxCharHeight);
+								strcat(Code,  Nr);
+								strcat(Code, ",  ");
+								sprintf(Nr,"%d",(x * MaxCharWidth) + CharWidths[y][x]-1);
+								strcat(Code, Nr);
+								strcat(Code, ",");
+								sprintf(Nr,"%d",((y+1) * MaxCharHeight)-1);	
+								strcat(Code,  Nr);
+								strcat(Code, ",  ");
+								sprintf(Nr,"%d",x * MaxCharWidth);
+								strcat(Code,  Nr);
+								strcat(Code, ",");
+								sprintf(Nr,"%d",y * MaxCharHeight);
+								strcat(Code,  Nr);
+								strcat(Code, ");\n");
+								
+								SDL_Color white = {255, 255, 255, 255};
+								SDL_Surface* Tmp = TTF_RenderText_Blended(Font, Char, white);
+								if(Tmp)
+								{
+									SDL_Texture* TmpTexture = SDL_CreateTextureFromSurface(TextRenderer, Tmp);
+									SDL_Rect rect; 
+									rect.x = x * MaxCharWidth;  
+									rect.y = y * MaxCharHeight;
+									rect.w = Tmp->w;
+									rect.h = Tmp->h;
+									SDL_RenderCopy(TextRenderer, TmpTexture, NULL, &rect);
+									SDL_DestroyTexture(TmpTexture);
+									SDL_FreeSurface(Tmp);
+								}
+							}
+						
+						char FontVar[1000];
+						strcpy(FontVar, "Font");
+						strcat(FontVar, FontName);
+						strcat(Code,"\n");
+						strcat(Code, FontVar);
+						strcat(Code, ".character_height = ");
+						sprintf(Nr,"%d",MaxCharHeight);
+						strcat(Code, Nr);
+						strcat(Code, ";\n");
+
+						strcat(Code, FontVar);
+						strcat(Code, ".use_variable_width = true;\n");
+						
+						strcat(Code, FontVar);
+						strcat(Code, ".character_separation = 0;\n");
+						strcat(Code, FontVar);
+						strcat(Code, ".line_separation = 0;\n\n");
+
+						strcat(Code, FontVar);
+						strcat(Code, ".texture_id = ");
+						strcat(Code, FontName);
+						strcat(Code, "_texture_id;\n");
+
+						strcat(Code, FontVar);
+						strcat(Code, ".character_zero_region_id = ");
+						strcat(Code, FontName);
+						strcat(Code, "_region_id;\n");
+
+						strcat(Code,"textfont_read_region_widths(&");
+						strcat(Code, FontVar);
+						strcat(Code, ");\n\n");
+
+						strcat(Code, "}\n");
+						strcat(Code, "#endif\n");
+						
+						char FileNamePng[1000];
+						strcpy(FileNamePng, FontName);
+						strcat(FileNamePng, ".png");
+						IMG_SavePNG(TextSurface, FileNamePng);
+						SDL_DestroyRenderer(TextRenderer);
+						SDL_FreeSurface(TextSurface);
+						SDL_DestroyRenderer(Renderer);
+						SDL_FreeSurface(RendererSurface);
+						
+						char FileNameHeader[1000];
+						strcpy(FileNameHeader, FontName);
+						strcat(FileNameHeader, ".h");
+						FILE *Fp = fopen(FileNameHeader, "w+");
+						if(Fp)
+						{
+							fwrite(Code, sizeof(char), strlen(Code), Fp);
+							fclose(Fp);
+						}
+						SDL_Log("Created Font with size per char: %dx%d", MaxCharWidth, MaxCharHeight);
+					}
+					else
+					{
+						SDL_Log("failed opening font '%s': %s", argv[1], SDL_GetError());
+					}
+					
+				}
+				else
+				{
+					SDL_Log("Failed to create renderer: %s\n", SDL_GetError());
+				}
+				TTF_Quit();	
+			}
+			else
+			{
+				SDL_Log("Failed to initialise SDL_TTF: %s\n", SDL_GetError());
+			}
+			IMG_Quit();	
+		}
+		else
+		{
+			SDL_Log("Failed to initialise SDL_Image: %s\n", SDL_GetError());
+		}
+		SDL_Quit();
+	}
+	else
+		SDL_Log("Failed to initialise SDL: %s\n", SDL_GetError());
+	return 1;
+}

--- a/Tools/ttftovircon32/vcpkg-configuration.json
+++ b/Tools/ttftovircon32/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "e832b2a0d2c9bcf0f69160ee5c52c372112ac0f6",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/Tools/ttftovircon32/vcpkg.json
+++ b/Tools/ttftovircon32/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": [
+    "sdl2",
+    "sdl2-image",
+    "sdl2-ttf"
+  ]
+}


### PR DESCRIPTION
A Small program that can convert TTF fonts to images and code used by the Vircon32 [Textfonts library](https://github.com/vircon32/ConsoleSoftware/tree/main/Libraries/TextFonts)