### PR TITLE
feature/add-ocean-storm-to-games

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Assets/emulationstation-themes"]
 	path = Assets/emulationstation-themes
 	url = https://github.com/Chandler-Kluser/vircon32-libretro-theme-resources.git
+[submodule "Games/OceanStorm"]
+	path = Games/OceanStorm
+	url = https://github.com/Jastro/OceanStorm


### PR DESCRIPTION
# Added Ocean Storm to the list of games 🎮🌊

## Description
I have added the game **Ocean Storm** as a submodule to the repository. This game is now part of the listed projects, allowing for easy integration and access to its content.

## Changes Made
- Added the submodule using the following command:
  ```bash
  git submodule add https://github.com/Jastro/OceanStorm Games/OceanStorm

## Purpose
To integrate Ocean Storm into the list of available games, making it accessible and collaborative for contributors.

## How to Test
- Clone the repository.
- Update the submodules using the following command:
`git submodule update --init --recursive`
Check the Games/OceanStorm folder to ensure the submodule’s content is loaded correctly.

## Additional Notes
If you have any feedback or suggestions to improve the integration, feel free to share them. 😊

Thank you for reviewing this contribution! 🙌